### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
     branches: [ main ]
   pull_request:
 
+permissions:
+  contents: read
+  packages: write
+
 env:
   IMAGE_NAME: oss-deps-explorer
   REGISTRY: ${{ secrets.REGISTRY }}


### PR DESCRIPTION
Potential fix for [https://github.com/stevologic/oss-deps-explorer/security/code-scanning/1](https://github.com/stevologic/oss-deps-explorer/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will define the minimal permissions required for the workflow to function correctly. Based on the workflow's steps, the following permissions are needed:
- `contents: read` for accessing the repository's contents.
- `packages: write` for pushing Docker images to the registry.

The `permissions` block will be added at the root level, ensuring that all jobs in the workflow inherit these permissions unless overridden.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
