### PR TITLE
chore: harden container base images for SCA findings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.24-alpine AS build
+FROM golang:1.24.6-alpine3.21 AS build
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
@@ -7,7 +7,7 @@ COPY . .
 RUN CGO_ENABLED=0 go build -o /oss-deps-explorer ./cmd/oss-deps-explorer
 
 # Runtime stage
-FROM alpine:3.18
+FROM alpine:3.21
 RUN adduser -D app
 USER app
 COPY --from=build /oss-deps-explorer /usr/local/bin/oss-deps-explorer

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:alpine
+FROM nginx:1.27-alpine3.21
 COPY . /usr/share/nginx/html
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
### Motivation
- SCA tooling could not be run in this environment due to outbound restrictions to Go proxy/GitHub and missing scanner binaries, so base images were pinned/updated to reduce known CVE exposure, supply-chain drift, and improve reproducibility.

### Description
- Updated backend build image from `golang:1.24-alpine` to `golang:1.24.6-alpine3.21`, backend runtime from `alpine:3.18` to `alpine:3.21`, and UI image from `nginx:alpine` to `nginx:1.27-alpine3.21` by modifying `Dockerfile` and `ui/Dockerfile`.

### Testing
- Ran `go test ./...` which passed, and attempted `govulncheck` and `go list -m -u` (and other SCA scanner invocations) which failed due to network/Go proxy/GitHub restrictions and missing scanner binaries in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e12c8e1248332aa31b2240e4217ca)