### PR TITLE
chore: upgrade selected Go module versions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,11 +8,11 @@ require (
 	github.com/go-redis/redis/v8 v8.11.5
 	github.com/gorilla/mux v1.8.1
 	github.com/package-url/packageurl-go v0.1.3
-	golang.org/x/mod v0.26.0
+	golang.org/x/mod v0.28.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
-	github.com/cespare/xxhash/v2 v2.1.2 // indirect
+	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 )


### PR DESCRIPTION
### Motivation
- Bump a couple of outdated Go module versions in `go.mod` to pick up fixes and newer APIs.

### Description
- Updated `golang.org/x/mod` from `v0.26.0` to `v0.28.0` and updated the indirect `github.com/cespare/xxhash/v2` from `v2.1.2` to `v2.3.0` in `go.mod` and committed the change.

### Testing
- Ran `go build ./...` and `go mod tidy`, both of which failed to complete because the environment cannot download modules from `proxy.golang.org` (received `403 Forbidden`), so checksums in `go.sum` could not be refreshed in this run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e13e705808332b92ecea3acfc88a6)